### PR TITLE
Предложение: Добавить *.pyc в .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ node_modules
 # Logs
 *.log
 
+# Python compiled files
+*.pyc
+
 # Misc
 .DS_Store
 .fleet


### PR DESCRIPTION
**Описание проблемы**
В репозитории отсутствует правило для исключения файлов *.pyc, которые автоматически генерируются интерпретатором Python при выполнении скриптов. Эти файлы не являются частью исходного кода, не несут полезной информации для разработки и  засоряют историю коммитов.

**Почему это важно**
*.pyc файлы — артефакты выполнения, а не код разработчика: они всегда пересоздаются автоматически.
Их добавление в репозиторий увеличивает «шум» в изменениях и усложняет код-ревью.
Разные версии Python могут по-разному генерировать байткод, что приводит к ненужным конфликтам.
Исключение таких файлов — общепринятая практика в Python-проектах, повышающая чистоту репозитория.

**Предлагаемое решение**
Добавить строку:
`*.pyc`
в .gitignore.